### PR TITLE
fix race condition with timer expiry submission of null answer value

### DIFF
--- a/frontend/src/containers/TriviaForm.tsx
+++ b/frontend/src/containers/TriviaForm.tsx
@@ -2,8 +2,15 @@ import { useState } from "react";
 import { useGameContext } from "../context/useGameContext";
 import Button from "../components/Button";
 import GameAnswers from "../components/GameAnswers";
+import type { Question } from "../types/types";
 
-const TriviaForm = ({ answers }: { answers: string[] }) => {
+const TriviaForm = ({
+  answers,
+  activeQuestion,
+}: {
+  answers: string[];
+  activeQuestion: Question;
+}) => {
   const [selected, setSelected] = useState<string | null>(null);
   const { submitAnswer } = useGameContext();
 
@@ -12,23 +19,15 @@ const TriviaForm = ({ answers }: { answers: string[] }) => {
       className="flex flex-col gap-8 w-full max-w-4xl px-8"
       onSubmit={(e) => {
         e.preventDefault();
-        submitAnswer(selected);
+        submitAnswer(selected, activeQuestion);
       }}
     >
       {answers ? (
-        <GameAnswers
-          answers={answers}
-          selected={selected}
-          setSelected={setSelected}
-        />
+        <GameAnswers answers={answers} selected={selected} setSelected={setSelected} />
       ) : (
         <p>Something went wrong: Couldn't find answers</p>
       )}
-      <Button
-        disabled={!selected}
-        className="btn-xl col-span-2 mx-auto"
-        type="submit"
-      >
+      <Button disabled={!selected} className="btn-xl col-span-2 mx-auto" type="submit">
         Submit
       </Button>
     </form>

--- a/frontend/src/context/GameContext.tsx
+++ b/frontend/src/context/GameContext.tsx
@@ -31,7 +31,7 @@ export type GameContextType = {
   startGame: () => void;
   retryGame: () => void;
   endGame: () => void;
-  submitAnswer: (submitted: string | null) => void;
+  submitAnswer: (submitted: string | null, question: Question | RetryQuestion) => void;
   loadNextQuestion: () => void;
   saveGame: () => void;
 };

--- a/frontend/src/context/GameProvider.tsx
+++ b/frontend/src/context/GameProvider.tsx
@@ -204,10 +204,11 @@ const GameProvider = ({ children }: PropsWithChildren) => {
     setScore(0);
   };
 
-  const submitAnswer = (submitted: string | null) => {
-    // NORMAL MODE
-    if (incorrectQuestions.length === 0) {
-      const wasCorrect = submitted === questions[currentIndex].correctAnswer;
+  const submitAnswer = (submitted: string | null, question: Question | RetryQuestion) => {
+    if (!question) return;
+
+    if ("correctAnswer" in question) {
+      const wasCorrect = submitted === question.correctAnswer;
 
       const answer: Answer = {
         questionIndex: currentIndex,
@@ -226,14 +227,13 @@ const GameProvider = ({ children }: PropsWithChildren) => {
       }
 
       // RETRY MODE
-    } else if (incorrectQuestions.length > 0) {
-      const currentRetryQuestion = incorrectQuestions[currentIndex];
-
-      const wasCorrect = submitted === currentRetryQuestion.question.correctAnswer;
+    } else {
+      const retryQ = question as RetryQuestion;
+      const wasCorrect = submitted === question.question.correctAnswer;
 
       // update DB archive status
       const archiveOption: RetryQuestionResponse = {
-        id: currentRetryQuestion.id,
+        id: retryQ.id,
         archived: wasCorrect,
       };
 

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -14,7 +14,6 @@ const GamePage = () => {
     incorrectQuestions,
     currentIndex,
     gameState,
-    loadNextQuestion,
     submitAnswer,
     score,
     loading,
@@ -25,34 +24,39 @@ const GamePage = () => {
   const navigate = useNavigate();
 
   const isRetryMode = incorrectQuestions.length > 0;
+
   const activeQuestion = isRetryMode
     ? incorrectQuestions[currentIndex]?.question
     : questions[currentIndex];
 
-  const handleTimeout = () => {
-    if (gameState !== "playing") return;
-    submitAnswer(null);
-    loadNextQuestion();
-  };
-
   useEffect(() => {
-    if (gameState !== "playing") return;
+    if (gameState !== "playing" || !activeQuestion) return;
 
     setTimeLeft(15);
+
     const interval = setInterval(() => {
       setTimeLeft((prev) => {
         if (prev <= 1) {
           clearInterval(interval);
-          // wait til next tick so render isn't disrupted
-          setTimeout(() => handleTimeout(), 0);
+
+          setTimeout(() => {
+            console.log("Timer expired, submitting null for:", activeQuestion);
+
+            submitAnswer(
+              null,
+              isRetryMode ? incorrectQuestions[currentIndex] : activeQuestion
+            );
+          }, 0);
+
           return 0;
         }
+
         return prev - 1;
       });
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [gameState, currentIndex]);
+  }, [gameState, currentIndex, activeQuestion]);
 
   useEffect(() => {
     if (gameState === "finished") {
@@ -101,7 +105,7 @@ const GamePage = () => {
         <div className="game-container flex flex-col items-center">
           <GameStatBar timeLeft={timeLeft} score={score} />
           <TriviaQuestion question={activeQuestion} currentIndex={currentIndex} />
-          <TriviaForm answers={shuffledAnswers} />
+          <TriviaForm answers={shuffledAnswers} activeQuestion={activeQuestion} />
         </div>
       )}
     </>


### PR DESCRIPTION
When the countdown timer hit zero, the game would submit an undefined question/answer. This was caused by a race condition where the currentIndex state was being incremented before the timeout handler could access the correct question. This means that submitAnswer received an undefined question, preventing the game from comparing/accessing the submitted answer with the correct answer.

"ncaught TypeError: Cannot read properties of undefined (reading 'correctAnswer')"

Solution:
- stopped looking up the current question INSIDE the callback (now captures the question BEFORE)
- passes question WITH submitted answer
- activeQuestion is in dependency array
- checks loading state
- more consise logic that is not scattered
- other changes in GameProvider to handle the question being passed with the submittedAnswer